### PR TITLE
docs/apis/tools: move REAPI outside of bazel

### DIFF
--- a/doc/apis/tool.rst
+++ b/doc/apis/tool.rst
@@ -162,10 +162,8 @@ References
 
     * `Argo Workflows - The workflow engine for Kubernetes <https://argoproj.github.io/argo-workflows/>`__
     * `bazel.build <https://bazel.build/>`__
-
-      * `bazelbuild/remote-apis <https://github.com/bazelbuild/remote-apis>`__
       * `hdl/bazel_rules_hdl <https://github.com/hdl/bazel_rules_hdl>`__
-
+    * `Remote Execution API <https://github.com/bazelbuild/remote-apis>`__
     * `cmake.org <https://cmake.org/>`__
     * `gradle.org <https://gradle.org/>`__
     * `ninja-build.org <https://ninja-build.org/>`__


### PR DESCRIPTION
Since there are other implementations (client and server) besides bazel:
https://github.com/bazelbuild/remote-apis#clients
